### PR TITLE
Update homepage CTA links

### DIFF
--- a/homepage.html
+++ b/homepage.html
@@ -37,7 +37,7 @@
             <div class="flex gap-2">
               <button
                 class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#1982e5] text-slate-50 text-sm font-bold leading-normal tracking-[0.015em]"
-                onclick="window.location.href='choosewebsitetemplate.html'"
+                onclick="window.location.href='theme.html'"
               >
                 <span class="truncate">Try for free</span>
               </button>
@@ -69,7 +69,7 @@
                   </div>
                   <button
                     class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 @[480px]:h-12 @[480px]:px-5 bg-[#1982e5] text-slate-50 text-sm font-bold leading-normal tracking-[0.015em] @[480px]:text-base @[480px]:font-bold @[480px]:leading-normal @[480px]:tracking-[0.015em]"
-                    onclick="window.location.href='choosewebsitetemplate.html'"
+                    onclick="window.location.href='theme.html'"
                   >
                     <span class="truncate">Try for free</span>
                   </button>
@@ -187,7 +187,7 @@
                   <div class="flex justify-center">
                     <button
                       class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 @[480px]:h-12 @[480px]:px-5 bg-[#1982e5] text-slate-50 text-sm font-bold leading-normal tracking-[0.015em] @[480px]:text-base @[480px]:font-bold @[480px]:leading-normal @[480px]:tracking-[0.015em] grow"
-                      onclick="window.location.href='choosewebsitetemplate.html'"
+                      onclick="window.location.href='theme.html'"
                     >
                       <span class="truncate">Try for free</span>
                     </button>


### PR DESCRIPTION
## Summary
- link all "Try for free" buttons to `theme.html` so they start the onboarding

## Testing
- `grep -n theme.html homepage.html`

------
https://chatgpt.com/codex/tasks/task_e_684dd9534dc0832d87f31c02e4dde01d