### PR TITLE
Fix Next.js client error on home page

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,3 +1,5 @@
+"use client";
+
 export default function HomePage() {
   return (
     <div className="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Manrope, "Noto Sans", sans-serif;'>


### PR DESCRIPTION
## Summary
- add the `"use client"` directive to `src/app/page.jsx` so event handlers work

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e45a739e8832dbd5ac70a6334219f